### PR TITLE
Allow buttressing commas, ordinals

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ Or install it yourself as:
 ```ruby
 text = "1988-1990 and 2000 and one more date 04.04.2015"        # parsing text
 key_words = ['between','-']                                     # you can define special separator
-date_format = {date_format: :usa}                               # year,day,month by default year,month,day
-dates_from_string = DatesFromString.new(key_words,date_format)  # define DatesFromString object
+options = {
+  date_format: :usa,                                            # year,day,month by default year,month,day
+  ordinals: ['nd', 'st', 'th']                                  # a string list that might accompany a day, default none
+}                               
+dates_from_string = DatesFromString.new(key_words, options)     # define DatesFromString object
 dates_from_string.get_structure(text)                           # parsing text
 
 #=> returns
@@ -128,6 +131,15 @@ obj.get_structure(input)
 #=> return
 # [{:type=>:year, :value=>"1960", :distance=>2, :key_words=>['and']},
 # {:type=>:year, :value=>"1965", :distance=>0, :key_words=>[]},]
+
+dates_from_string_with_ordinals = DatesFromString.new(['and'], ordinals: ['st', 'th', 'nd'])
+input = 'around September 2nd, 2013'
+dates_from_string_with_ordinals.get_structure(input)
+
+#=> return
+# [{:type=>:month, :value=>"09", :distance=>1, :key_words=>[]},
+# {:type=>:day, :value=>"2", :distance=>1, :key_words=>[]},
+# {:type=>:year, :value=>"2013", :distance=>0, :key_words=>[]}]
 
 input = "In September 2011, following a change in the law extending
          the presidential term from four years to six,[5] Putin announced

--- a/spec/dates_from_string_spec.rb
+++ b/spec/dates_from_string_spec.rb
@@ -390,7 +390,7 @@ describe DatesFromString do
       expect(subject.get_structure(input)).to eq(output)
     end
 
-    it 'find year.moth' do
+    it 'find year.month' do
       input = "1964.10"
       output = [
         {:type=>:year, :value=>"1964", :distance=>0, :key_words=>[]},
@@ -494,6 +494,62 @@ describe DatesFromString do
       ]
 
       expect(subject.get_structure(input)).to eq(output)
+    end
+
+    it 'finds full date year month and day in USA comma-delimited format' do
+      input = 'February 2, 2015'
+      output = [
+        {:type=>:month, :value=>"02", :distance=>1, :key_words=>[]},
+        {:type=>:day, :value=>"2", :distance=>1, :key_words=>[]},
+        {:type=>:year, :value=>"2015", :distance=>0, :key_words=>[]}
+      ]
+
+      expect(subject.get_structure(input)).to eq(output)
+    end
+
+    it 'finds day when sepcified with a single digit' do
+      input = '2 Feb in the year 2015'
+      output = [
+        {:type=>:day, :value=>"2", :distance=>1, :key_words=>[]},
+        {:type=>:month, :value=>"02", :distance=>4, :key_words=>[]},
+        {:type=>:year, :value=>"2015", :distance=>0, :key_words=>[]}
+      ]
+
+      expect(subject.get_structure(input)).to eq(output)
+    end
+
+    it 'finds date when abbreviated month buttressed by comma' do
+      input = '2 Feb, 2015'
+      output = [
+        {:type=>:day, :value=>"2", :distance=>1, :key_words=>[]},
+        {:type=>:month, :value=>"02", :distance=>1, :key_words=>[]},
+        {:type=>:year, :value=>"2015", :distance=>0, :key_words=>[]}
+      ]
+
+      expect(subject.get_structure(input)).to eq(output)
+    end
+
+    it 'finds date when month buttressed by comma' do
+      input = '2 February, 2015'
+      output = [
+        {:type=>:day, :value=>"2", :distance=>1, :key_words=>[]},
+        {:type=>:month, :value=>"02", :distance=>1, :key_words=>[]},
+        {:type=>:year, :value=>"2015", :distance=>0, :key_words=>[]}
+      ]
+
+      expect(subject.get_structure(input)).to eq(output)
+    end
+
+    it 'finds day with a specified "nd" ordinal' do
+      dates_from_string_with_ordinals = DatesFromString.new(['between','-'], ordinals: ['nd'])
+      input = '2nd of Feb, 2015'
+      output = [
+        {:type=>:day, :value=>"2", :distance=>2, :key_words=>[]},
+        {:type=>:month, :value=>"02", :distance=>1, :key_words=>[]},
+        {:type=>:year, :value=>"2015", :distance=>0, :key_words=>[]}
+      ]
+
+      expect(dates_from_string_with_ordinals.get_structure(input)).to eq(output)
     end
 
     it 'find dates in simple structure' do

--- a/spec/dates_from_string_spec.rb
+++ b/spec/dates_from_string_spec.rb
@@ -552,6 +552,30 @@ describe DatesFromString do
       expect(dates_from_string_with_ordinals.get_structure(input)).to eq(output)
     end
 
+    it 'finds day with a specified "st" ordinal' do
+      dates_from_string_with_ordinals = DatesFromString.new(['between','-'], ordinals: ['st'])
+      input = '1st of Feb, 2015'
+      output = [
+        {:type=>:day, :value=>"1", :distance=>2, :key_words=>[]},
+        {:type=>:month, :value=>"02", :distance=>1, :key_words=>[]},
+        {:type=>:year, :value=>"2015", :distance=>0, :key_words=>[]}
+      ]
+
+      expect(dates_from_string_with_ordinals.get_structure(input)).to eq(output)
+    end
+
+    it 'finds day with a specified "th" ordinal' do
+      dates_from_string_with_ordinals = DatesFromString.new(['between','-'], ordinals: ['th'])
+      input = '4th of Feb, 2015'
+      output = [
+        {:type=>:day, :value=>"4", :distance=>2, :key_words=>[]},
+        {:type=>:month, :value=>"02", :distance=>1, :key_words=>[]},
+        {:type=>:year, :value=>"2015", :distance=>0, :key_words=>[]}
+      ]
+
+      expect(dates_from_string_with_ordinals.get_structure(input)).to eq(output)
+    end
+
     it 'find dates in simple structure' do
       input = '23.04.2013'
       output = ['2013-04-23']


### PR DESCRIPTION
Thank you for this gem. It provides a very pleasant way of dealing with date information in a given blob of text.

I ran into two issues when incorporating it into a project:

- For better or worse (OK, definitely for worse), the USA loves to put the month first for a given date. While the gem accommodates this for fully numeric dates, it does not account for _very_ common written form, e.g., "January 20, 2017". It appears this is caused by the fact that a date token is buttressed by a ",".

- There is no support for ordinals, e.g., "2nd of November 2017." The "2nd" does not parse correctly.

This PR tries to solve both these issues. For the first, it recognizes that "," might be part of any given date or month token. For the second, it adds an `ordinals` option whereby a specific list can be provided to match against day token candidates.