### PR TITLE
Prepare v1.3.0 for release

### DIFF
--- a/dates_from_string.gemspec
+++ b/dates_from_string.gemspec
@@ -29,9 +29,9 @@ Gem::Specification.new do |spec|
   # Only with ruby 2.0.x
   spec.required_ruby_version = '~> 2.0'
 
-  spec.add_development_dependency "bundler", "~> 1.13.6"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec", "~> 3.9"
 
 
   spec.add_development_dependency 'pry-rails'

--- a/lib/dates_from_string/version.rb
+++ b/lib/dates_from_string/version.rb
@@ -1,3 +1,3 @@
 class DatesFromString
-  VERSION = "1.2.4"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
* Allow buttressing commas, ordinals

This Release imposes two fixes to improve date parsing:

- The USA commonly uses dates in a format like "January 20, 2017".
  Previous code would not parse "20," correctly because the string
  token included a comma. There is a similar impact on any given
  month date. This fix recognizes the possibility of a comma.

- There is no support for ordinals. "20th of January 2017" would
  not correctly parse. This commit solves this problem by adding
  an "ordinals" option on initialization. Any passed ordinals are
  deemed to validly be part of a day token.

* Add more ordinal specs

Thank You @niborg 